### PR TITLE
Performance improvements through unsafe array access

### DIFF
--- a/Sources/BigInt/Limbs.swift
+++ b/Sources/BigInt/Limbs.swift
@@ -42,7 +42,7 @@ extension Array where Element == Limb {
     }
 
     mutating func ensureSize(_ size: Int) {
-        self.reserveCapacity(size + 4)
+        self.reserveCapacity(size)
         while self.count < size {
             self.append(0)
         }


### PR DESCRIPTION
Hello there, first of all, thanks for making this nifty BigInt library.

While working with it (doing a Fibonacci implementation, which results in millions of repeated adds, and extremely large values - `magnitude.count` > 10k), I found a performance bottleneck relating to array bounds checking, and that performance is noticeably improved by taking advantage of Swift Array's [withUnsafeMutableBufferPointer](https://developer.apple.com/documentation/swift/array/withunsafemutablebufferpointer(_:)).

Here's the performance chart that show that the improvements increase as you calculate larger Fibonacci numbers (the horizontal axis is the Fibonacci number - larger number means more iterations, and larger magnitudes):
![fibonacci](https://user-images.githubusercontent.com/596034/226696755-43586887-e93d-4fd7-8ce5-a5a90401d5a0.svg)

These were conducted using [Swift Collections Benchmark](https://github.com/apple/swift-collections-benchmark), I'll be happy to share the full project with you if you are interested. But here's the Fibonacci implementation:
```swift
func fibonacci(_ n: Int) -> BInt {
    var fib = BInt.ZERO, lastFib = BInt.ONE
    
    if n < 1 {
        return fib
    }
    for _ in 1...n {
        lastFib += fib
        swap(&fib, &lastFib)
    }
    return fib
}
```

## Context
For more context on why I started to look into this in the first place: For a fun project, I was implementing Fibonacci in various different languages, and found Swift to be the slowest. For instance, to calculate `fibonacci(1_000_000)` took:
- ~3s in Go
- ~8s in Scala (on the JVM, and likely will be the same in any JVM language)
- ~28s in Swift (~21s when using the optimizations in this PR)

I'm going to continue profiling/researching to see if I can get the Swift version faster, but thought I'd share what I have for now.

## Unrelated - `Array.reserveCapacity()`
Not really related to this change, but while going through the code, I saw that you were calling `Array.reserveCapacity(...)` [here](https://github.com/leif-ibsen/BigInt/blob/master/Sources/BigInt/Limbs.swift#L45).

The Swift documentation seems to suggest this is a bad idea - [Preserving an Array's Geometric Growth Strategy](https://developer.apple.com/documentation/swift/array/reservecapacity(_:)-5cknc#Preserving-an-Arrays-Geometric-Growth-Strategy).

Having said that, I tried removing that line of code, saw no difference in performance, and reverted it.