### PR TITLE
Add Linux support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,14 +13,16 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "3.1.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "BigInt",
-            dependencies: []),
+            dependencies: [
+                .product(name: "Crypto", package: "swift-crypto", condition: .when(platforms: [.linux])),
+            ]),
         .testTarget(
             name: "BigIntTests",
             dependencies: ["BigInt"]),

--- a/Sources/BigInt/SecRandom.swift
+++ b/Sources/BigInt/SecRandom.swift
@@ -1,0 +1,19 @@
+#if !os(macOS)
+
+import Foundation
+import CCryptoBoringSSL
+
+// this is an inaccurate port of SecRandomCopyBytes.
+
+public typealias SecRandomRef = Int
+public let kSecRandomDefault: SecRandomRef = 0
+public let errSecParam = -50
+public let errSecSuccess = 0
+
+public func SecRandomCopyBytes(_ rnd: SecRandomRef, _ count: size_t, _ bytes: UnsafeMutableRawPointer) -> Int 
+{
+    CCryptoBoringSSL_RAND_bytes(bytes, count)
+	return errSecSuccess;
+}
+
+#endif


### PR DESCRIPTION
This implements a stub for `SecRandomCopyBytes` uses swift-crypto/BoringSSL's DRBG for secure random generation.